### PR TITLE
update to latest `seqneut-pipeline` dev version for faster curve plotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,16 +6,15 @@ _*
 docs/*
 !docs/*.html
 
-**/.ipynb_checkpoints/
-**/.ipynb_checkpoints/**
-**/.DS_Store
-**/._*
-**/.*
+results/*
 
-results/logs
-
+!results/barcode_counts
 results/barcode_counts/*
 !results/barcode_counts/*.csv
+
+!results/barcode_fates
+results/barcode_fates/*
+!results/barcode_fates/*.csv
 
 !results/plates
 results/plates/*/*
@@ -24,26 +23,26 @@ results/plates/*/*
 !results/plates/*/qc_drops.yml
 
 !results/miscellaneous_plates
-!results/miscellaneous/*/*
+results/miscellaneous_plates/*/*
+!results/miscellaneous_plates/*/*counts.csv
+!results/miscellaneous_plates/*/*fates.csv
 
 !results/sera
 results/sera/*/*
-!results/sera/sera_by_plate.csv
+!results/sera/groups_sera_by_plate.csv
 !results/sera/*/titers.csv
 !results/sera/*/titers_per_replicate.csv
 !results/sera/*/qc_drops.yml
 
 !results/aggregated_titers
 results/aggregated_titers/*
-!results/aggregated_titers/*.csv
+!results/aggregated_titers/titers*.csv
 
 !results/qc_drops
 results/qc_drops/*
-!results/qc_drops/plate_qc_drops.yml
-!results/qc_drops/sera_qc_drops.yml
+!results/qc_drops/*.yml
 
-
-non-pipeline_analyses/nextstrain_tree_build/data/download/*
-non-pipeline_analyses/nextstrain_tree_build/data/concatenated_files/*
-
-non-pipeline_analyses/flu_circulating_frequencies/data/*
+!results/miscellaneous_plates
+results/miscellaneous_plates/*/*
+!results/miscellaneous_plates/*/*counts.csv
+!results/miscellaneous_plates/*/*fates.csv


### PR DESCRIPTION
@ckikawa, this pull request is currently **a step** towards faster running of pipeline. See below, but basically merge this pull request if you need to run pipeline more for the stuff you are doing; if you aren't running pipeline yet then you can hold off on merging.

Briefly, this updates to the latest `seqneut-pipeline`, which has some but not all of the changes that will make it run faster. It still errors at the very end. I am fixing those things now. But this is faster: it takes about 1.25 hours to run the whole thing as compared to 5+ hours. Note that because of an updated `conda` env it will re-run barcode counting too, but that is pretty quick.

Note also that I just updated the pipeline and configuration, not yet the results output by running it.

Since I am working on improving pipeline and you are using it to analyze data, we need to keep relatively synced or it will be a disaster when we have to merge stuff. So basically:

**If you need to run pipeline now**, then merge this pull request and then make sure you are on the latest main branch after merging and run that. (If you need to make changes to data, etc, make a new pull request with the results.)

**If you do not need to run pipeline now**, then you can just wait and I will keep pushing more changes to this branch as I make further improvements over next few days.

But only do one of the two above, don't do an intermediate of making your own runs or further changes on another branch without first merging this or it will become impossible to resolve.