### PR TITLE
add example plasmid maps

### DIFF
--- a/non-pipeline_analyses/library_design/plasmids/h1_example_barcoded_construct.gb
+++ b/non-pipeline_analyses/library_design/plasmids/h1_example_barcoded_construct.gb
@@ -1,0 +1,147 @@
+LOCUS       H1_example_barcoded_con 4782 bp ds-DNA     circular     30-AUG-2025
+DEFINITION  This is an exemplar barcoded H1 expression construct for sequencing
+            based neutralization assays described in Kikawa et al 2025. This is
+            a pHH plasmid containing upstream signal peptide and 3'NCR from
+            WSN, an ectodomain from an example H1 strain, a partially recoded
+            endodomain and  C-terminal domain from WSN, and double stop codons
+            at the end of the HA coding region. Following the coding HA coding
+            region there is a 16-nucleotide barcode (NNNNNNNNNNNNNNNN) followed
+            by an Illumina Read1 sequence and duplicated 5' packaging signals
+            from WSN containing a single stop codon.
+SOURCE      synthetic DNA construct
+  ORGANISM  synthetic DNA construct .
+COMMENT     Imported using the Genbank importer. File name:
+            h1_example_cloned.gb Imported using the Genbank importer. File
+            name: 4380_pHH_a-norway-08030-2023_duppack_barcoded_bc1_H1 (1).gb
+            Imported using the Genbank importer. File name:
+            H1_1_A-Norway-08030-2023_duppack_barcoded.gb
+FEATURES             Location/Qualifiers
+     CDS             complement(174..1031)
+                     /label="AmpR"
+                     /translation="MSIQHFRVALIPFFAAFCLPVFAHPETLVKVKDAEDQLGARVGYIELDLNSGKILESFRPEERFPMMSTFKVLLCGAVLSRVDAGQEQLGRRIHYSQNDLVEYSPVTEKHLTDGMTVRELCSAAITMSDNTAANLLLTTIGGPKELTAFLHNMGDHVTRLDRWEPELNEAIPNDERDTTMPVAMATTLRKLLTGELLTLASRQQLIDWMEADKVAGPLLRSALPAGWFIADKSGAGERGSRGIIAALGPDGKPSRIVVIYTTGSQATMDERNRQIAEIGASLIKHW"
+     terminator      complement(1576..1741)
+                     /label="mouse PolI terminator"
+     misc_feature    complement(1742..1753)
+                     /label="U12"
+     misc_feature    complement(1742..1773)
+                     /label="3' NCR"
+     misc_feature    1774..1833
+                     /label="WSN first 20 amino acids"
+     CDS             1774..3477
+                     /label="Translation 1774-3477"
+                     /translation="MKAKLLVLLYAFVATDADTICIGYHANNSTDTVDTVLEKNVTVTHSVNLLEDKHNGKLCKLRGVAPLHLGQCNIAGWILGNPECESLSTARSWSYIVETSNSENGTCYPGDFINYEELREQLSSVSSFERFEIFPKTSSWPNHDSDNGVTAACPHAGAKSFYKNLIWLVKKGKSYPKINQTYINDKGKEVLVLWGIHHPPTITDQESLYQNADAYVFVGTSRYSKKFKPEIATRPKVRDQAGRMNYYWTLVEPGDKITFEATGNLVAPRYAFTMEKDAGSGIIISDTPVHDCNTTCQTPEGAINTSLPFQNVHPITIGKCPKYVRSTKLRLATGLRNVPSIQSRGLFGAIAGFIEGGWTGMVDGWYGYHHQNEQGSGYAADLKSTQNAIDKITNKVNSVIEKMNTQFTAVGKEFNHLEKRIENLNKKVDDGFLDVWTYNAELLVLLENERTLDYHDSNVKNLYEKVRNQLKNNAKEIGNGCFEFYHKCDNTCMESVKNGTYDYPKYSEEAKLNREKIDGVKLESMGVYQILAIYSTVASSLVLLVSLGAISFWMCSNGSLQCRICI**"
+     misc_feature    1805..1833
+                     /label="upstream insert homology"
+     misc_feature    1805..3513
+                     /label="region ordered from Twist Biosciences"
+     misc_feature    1834..3333
+                     /label="example H1 ectodomain"
+     misc_feature    3334..3477
+                     /label="WSN partially recoded endodomain"
+     misc_feature    3372..3477
+                     /label="WSN recoded endodomain"
+     misc_feature    3387..3387
+                     /label="T>A to remove NheI site"
+     misc_feature    3478..3493
+                     /label="Barcode"
+     misc_feature    3494..3513
+                     /label="downstream insert homology"
+     misc_feature    3494..3526
+                     /label="Illumina Read1"
+     misc_feature    3527..3534
+                     /label="NotI"
+     misc_feature    3536..3640
+                     /label="WSN packaging signal"
+     CDS             3536..3640
+                     /label="Translation 3536-3640"
+                     /translation="IYSTVASSLVL*VSLGAISFWMCSNGSLQCRICI*"
+     misc_feature    3604..3604
+                     /label="T > A"
+     misc_feature    complement(3641..3685)
+                     /label="5' NCR"
+     misc_feature    complement(3674..3685)
+                     /label="U13"
+     misc_feature    complement(3686..4088)
+                     /label="Human PolI promoter"
+ORIGIN
+        1 gaagatcctt tgatcttttc tacggggtct gacgctcagt ggaacgaaaa ctcacgttaa
+       61 gggattttgg tcatgagatt atcaaaaagg atcttcacct agatcctttt aaattaaaaa
+      121 tgaagtttta aatcaatcta aagtatatat gagtaaactt ggtctgacag ttaccaatgc
+      181 ttaatcagtg aggcacctat ctcagcgatc tgtctatttc gttcatccat agttgcctga
+      241 ctccccgtcg tgtagataac tacgatacgg gagggcttac catctggccc cagtgctgca
+      301 atgataccgc gagacccacg ctcaccggct ccagatttat cagcaataaa ccagccagcc
+      361 ggaagggccg agcgcagaag tggtcctgca actttatccg cctccatcca gtctattaat
+      421 tgttgccggg aagctagagt aagtagttcg ccagttaata gtttgcgcaa cgttgttgcc
+      481 attgctacag gcatcgtggt gtcacgctcg tcgtttggta tggcttcatt cagctccggt
+      541 tcccaacgat caaggcgagt tacatgatcc cccatgttgt gcaaaaaagc ggttagctcc
+      601 ttcggtcctc cgatcgttgt cagaagtaag ttggccgcag tgttatcact catggttatg
+      661 gcagcactgc ataattctct tactgtcatg ccatccgtaa gatgcttttc tgtgactggt
+      721 gagtactcaa ccaagtcatt ctgagaatag tgtatgcggc gaccgagttg ctcttgcccg
+      781 gcgtcaacac gggataatac cgcgccacat agcagaactt taaaagtgct catcattgga
+      841 aaacgttctt cggggcgaaa actctcaagg atcttaccgc tgttgagatc cagttcgatg
+      901 taacccactc gtgcacccaa ctgatcttca gcatctttta ctttcaccag cgtttctggg
+      961 tgagcaaaaa caggaaggca aaatgccgca aaaaagggaa taagggcgac acggaaatgt
+     1021 tgaatactca tactcttcct ttttcaatat tattgaagca tttatcaggg ttattgtctc
+     1081 atgagcggat acatatttga atgtatttag aaaaataaac aaaagagttt gtagaaacgc
+     1141 aaaaaggcca tccgtcagga tggccttctg cttaatttga tgcctggcag tttatggcgg
+     1201 gcgtcctgcc cgccaccctc cgggccgttg cttcgcaacg ttcaaatccg ctcccggcgg
+     1261 atttgtccta ctcaggagag cgttcaccga caaacaacag ataaaacgaa aggcccagtc
+     1321 tttcgactga gcctttcgtt ttatttgatg cctggcagtt ccctactctc gcatggggag
+     1381 accccacact accatcggcg ctacggcgtt tcacttctga gttcggcatg gggtcaggtg
+     1441 ggaccaccgc gctactgccg ccaggcaaat tctgttttat cagaccgctt ctgcgttctg
+     1501 atttaatctg tatcaggctg aaaatcttct ctcatccgcc aaaacagcca aggcggccgc
+     1561 gctagcggcc gatcccccaa aaaaaaaaaa aaaaaaagag tccagagtgg ccccgccgct
+     1621 ccgcgccggg gggggggggg gggggggaca ctttcggaca tctggtcgac ctccagcatc
+     1681 gggggaaaaa aaaaaacaaa gtgtcgcccg gagtactggt cgacctccga agttgggggg
+     1741 gagcaaaagc aggggaaaat aaaaacaacc aaaatgaagg caaaactact ggtcctgtta
+     1801 tatgcatttg tagctacaga tgcagacaca atatgtatag gttatcatgc gaacaattca
+     1861 acagacactg tggacacagt actagaaaag aatgtaacag taacacactc tgtcaatctt
+     1921 ctagaagaca agcataacgg aaaactatgc aaactaagag gggtagcccc attgcatttg
+     1981 ggtcaatgta acattgctgg ctggatcctg ggaaatccag agtgtgaatc actctccaca
+     2041 gcaagatcat ggtcctacat tgtggaaaca tctaattcag aaaatggaac ttgttaccca
+     2101 ggagatttca tcaattatga ggagctaaga gagcaattga gctcagtgtc atcatttgaa
+     2161 aggtttgaaa tattccccaa gacaagttca tggcctaatc atgactcgga caatggtgta
+     2221 acggcagcat gtcctcacgc tggagcaaaa agcttctaca aaaacttgat atggctggtt
+     2281 aaaaaaggaa aatcataccc aaagatcaac caaacctaca ttaatgataa agggaaagaa
+     2341 gtcctcgtgc tgtggggcat tcaccatcca cccactatta ctgaccaaga aagtctctat
+     2401 cagaatgcag atgcatatgt ttttgtgggg acatcaagat acagcaagaa gttcaagccg
+     2461 gaaatagcaa caagacccaa agtgagggat caagcaggga gaatgaacta ttactggaca
+     2521 ctagtagaac cgggagacaa aataacattc gaagcaactg gtaatctagt ggcaccgaga
+     2581 tatgcattca caatggaaaa agatgctgga tctggtatta tcatttcaga tacaccagtc
+     2641 cacgattgca atacaacttg tcagacaccc gagggtgcta taaacaccag cctcccattt
+     2701 cagaatgtac atccgatcac gattgggaaa tgtccaaagt atgtgagaag cacaaaattg
+     2761 agactggcca caggactgag gaatgtcccg tctattcaat ctagaggcct atttggggcc
+     2821 attgctggct tcatcgaagg ggggtggaca gggatggtag atggatggta cggttatcac
+     2881 catcaaaatg agcaggggtc aggatatgca gccgatctga agagcacaca aaatgccatt
+     2941 gataagatta ccaacaaagt aaattctgtt attgaaaaga tgaatacaca gttcacagca
+     3001 gttggtaaag agttcaacca ccttgaaaaa agaatagaga atctaaataa aaaggttgat
+     3061 gatggtttcc tggacgtttg gacttacaat gccgaactgc tggttctact ggaaaacgaa
+     3121 agaactttgg actatcacga ttcaaatgtg aagaacttgt atgaaaaagt aagaaaccag
+     3181 ttaaaaaaca atgccaagga aattggaaac ggctgctttg aattttacca caaatgcgac
+     3241 aacacatgca tggaaagtgt caagaatggg acttatgact acccaaaata ctcagaggaa
+     3301 gcaaaattaa acagagaaaa aatagatgga gtaaaattgg aatcaatggg agtgtatcag
+     3361 attctggcga tatattctac agtggcaagc tccttagtac tgctagtttc tttaggagcg
+     3421 attagctttt ggatgtgctc caacggctcc ctacaatgtc ggatttgtat ttaatagnnn
+     3481 nnnnnnnnnn nnnagatcgg aagagcgtcg tgtagggaaa gagtgtgcgg ccgctatcta
+     3541 ctcaactgtc gccagttcac tggtgcttta ggtctccctg ggggcaatca gtttctggat
+     3601 gtgttctaat gggtctttgc agtgcagaat atgcatctga gattaggatt tcagaaatat
+     3661 aaggaaaaac acccttgttt ctactaataa cccggcggcc caaaatgccg actcggagcg
+     3721 aaagatatac ctcccccggg gccgggaggt cgcgtcaccg accacgccgc cggcccaggc
+     3781 gacgcgcgac acggacacct gtccccaaaa acgccaccat cgcagccaca cacggagcgc
+     3841 ccggggccct ctggtcaacc ccaggacaca cgcgggagca gcgccgggcc ggggacgccc
+     3901 tcccggccgc ccgtgccaca cgcagggggc cggcccgtgt ctccagagcg ggagccggaa
+     3961 gcattttcgg ccggcccctc ctacgaccgg gacacacgag ggaccgaagg ccggccaggc
+     4021 gcgacctctc gggccgcacg cgcgctcagg gagcgctctc cgactccgca cggggactcg
+     4081 ccagaaagga tcgtgatctg cattaatgaa tcaggggata acgcaggaaa gaacatgtga
+     4141 gcaaaaggcc agcaaaaggc caggaaccgt aaaaaggccg cgttgctggc gtttttccat
+     4201 aggctccgcc cccctgacga gcatcacaaa aatcgacgct caagtcagag gtggcgaaac
+     4261 ccgacaggac tataaagata ccaggcgttt ccccctggaa gctccctcgt gcgctctcct
+     4321 gttccgaccc tgccgcttac cggatacctg tccgcctttc tcccttcggg aagcgtggcg
+     4381 ctttctcata gctcacgctg taggtatctc agttcggtgt aggtcgttcg ctccaagctg
+     4441 ggctgtgtgc acgaaccccc cgttcagccc gaccgctgcg ccttatccgg taactatcgt
+     4501 cttgagtcca acccggtaag acacgactta tcgccactgg cagcagccac tggtaacagg
+     4561 attagcagag cgaggtatgt aggcggtgct acagagttct tgaagtggtg gcctaactac
+     4621 ggctacacta gaagaacagt atttggtatc tgcgctctgc tgaagccagt taccttcgga
+     4681 aaaagagttg gtagctcttg atccggcaaa caaaccaccg ctggtagcgg tggttttttt
+     4741 gtttgcaagc agcagattac gcgcagaaaa aaaggatctc aa
+//

--- a/non-pipeline_analyses/library_design/plasmids/h3_example_barcoded_construct.gb
+++ b/non-pipeline_analyses/library_design/plasmids/h3_example_barcoded_construct.gb
@@ -1,0 +1,133 @@
+LOCUS       H3_example_barcoded_con 4781 bp ds-DNA     circular     30-AUG-2025
+DEFINITION  .
+KEYWORDS    "Definition:This is an exemplar barcoded H3 expression construct
+            for sequencing based neutralization assays described in Kikawa et
+            al 2025. This is a pHH plasmid containing upstream signal peptide
+            and 3'NCR from WSN, an ectodomain from an example H3 strain, a
+            consensus H3 endodomain, a recoded C-terminal domain from WSN, and
+            double stop codons at the end of the HA coding region. Following
+            the coding HA coding region there is a 16-nucleotide barcode
+            (NNNNNNNNNNNNNNNN) followed by an Illumina Read1 sequence and
+            duplicated 5' packaging signals from WSN containing a single stop
+            codon." "Organism: synthetic DNA construct" "Source: synthetic DNA
+            construct"
+FEATURES             Location/Qualifiers
+     misc_feature    535..700
+                     /label="mouse PolI terminator"
+     misc_feature    701..712
+                     /label="U12"
+     misc_feature    701..732
+                     /label="3' NCR"
+     misc_feature    733..789
+                     /label="WSN first 19 amino acids"
+     CDS             733..2445
+                     /label="HA coding region"
+                     /translation="MKAKLLVLLYAFVATDADTQKIPGNDNSTATLCLGHHAVPNGTIVKTITNDRIEVTNATELVQNSSIGKICNSPHQILDGGNCTLIDALLGDPQCDGFQNKEWDLFVERSRANSSCYPYDVPDYASLRSLVASSGTLEFKNESFNWTGVKQNGTSSACKRGSSSSFFSRLNWLTSLNNIYPAQNVTMPNKEQFDKLYIWGVHHPDTDKNQFSLFAQSSGRITVSTKRSQQAVIPNIGSRPRVRDIPSRISIYWTIVKPGDILLINSTGNLIAPRGYFKIRSGKSSIMRSDAPIGKCKSECITPNGSIPNDKPFQNVNRITYGACPRYVKQSTLKLATGMRNVPEKQTRGIFGAIAGFIENGWEGMVDGWYGFRHQNSEGRGQAADLKSTQAAIDQISGKLNRLIGKTNEKFHQIEKEFSEVEGRVQDLEKYVEDTKIDLWSYNAELLVALENQHTIDLTDSEMNKLFEKTKKQLRENAEDMGNGCFKIYHKCDNACIGSIRNETYDHNVYRDEALNNRFQIKGVELKSGYKDWILWISFAMSCFLLCVALLGFIMWACQKGSLQCRICI**"
+     misc_feature    764..789
+                     /label="upstream sequence homology"
+     misc_feature    764..2481
+                     /label="region ordered from Twist Biosciences"
+     misc_feature    790..2292
+                     /label="example H3 ectodomain"
+     misc_feature    2293..2412
+                     /label="H3 consensus endodomain"
+     misc_feature    2341..2445
+                     /label="region recoded to avoid packaging signal homology"
+     misc_feature    2413..2445
+                     /label="WSN mutated packaging signal"
+     misc_feature    2446..2461
+                     /label="16N barcode"
+     misc_feature    2462..2481
+                     /label="downstream sequence homology"
+     misc_feature    2462..2494
+                     /label="Illumina read 1"
+     misc_feature    2504..2608
+                     /label="WSN packaging signal"
+     misc_feature    2609..2653
+                     /label="5' NCR"
+     misc_feature    2642..2653
+                     /label="U13"
+     misc_feature    2654..3056
+                     /label="human PolI promoter"
+ORIGIN
+        1 actcttcctt tttcaatatt attgaagcat ttatcagggt tattgtctca tgagcggata
+       61 catatttgaa tgtatttaga aaaataaaca aaagagtttg tagaaacgca aaaaggccat
+      121 ccgtcaggat ggccttctgc ttaatttgat gcctggcagt ttatggcggg cgtcctgccc
+      181 gccaccctcc gggccgttgc ttcgcaacgt tcaaatccgc tcccggcgga tttgtcctac
+      241 tcaggagagc gttcaccgac aaacaacaga taaaacgaaa ggcccagtct ttcgactgag
+      301 cctttcgttt tatttgatgc ctggcagttc cctactctcg catggggaga ccccacacta
+      361 ccatcggcgc tacggcgttt cacttctgag ttcggcatgg ggtcaggtgg gaccaccgcg
+      421 ctactgccgc caggcaaatt ctgttttatc agaccgcttc tgcgttctga tttaatctgt
+      481 atcaggctga aaattttttt GcGGccgcca aaacagccaa gctagcggcc gatccccaaa
+      541 aaaaaaaaaa aaaaaagagt ccagagtggc cccgccgctc cgcgccgggg gggggggggg
+      601 ggggggacac tttcggacat ctggtcgacc tccagcatcg ggggaaaaaa aaaaacaaag
+      661 tgtcgcccgg agtactggtc gacctccgaa gttggggggg agcaaaagca ggggaaaata
+      721 aaaacaacca aaatgaaggc aaaactactg gtcctgttat atgcatttgt agctacagat
+      781 gcagacacac aaaaaatacc tggaaatgac aatagcacgg caacgctgtg ccttgggcac
+      841 catgcagtac caaacggaac gatagtgaaa acaatcacaa atgaccgaat tgaagttact
+      901 aatgctactg agttggttca gaattcatca ataggtaaaa tatgcaacag tcctcatcag
+      961 atccttgatg gagggaactg cacactaata gatgctctat tgggggaccc tcagtgtgac
+     1021 ggctttcaaa ataaggaatg ggaccttttt gttgaacgaa gcagagccaa cagcagctgt
+     1081 tacccttatg atgtgccgga ttatgcctcc cttaggtcac tagttgcctc atccggaaca
+     1141 ctggagttta aaaatgaaag cttcaattgg accggagtca aacaaaacgg aacaagttct
+     1201 gcgtgcaaaa ggggatctag tagtagtttt tttagtagat taaattggtt gaccagctta
+     1261 aacaacatat atccagcaca gaacgtgact atgccaaaca aggaacaatt tgacaaattg
+     1321 tacatttggg gggttcacca cccggatacg gacaagaacc aattctccct gtttgctcaa
+     1381 tcatcaggaa gaatcacagt atctaccaaa agaagccaac aagctgtaat cccaaatatc
+     1441 ggatctagac ccagagtaag ggatatccct agcagaataa gcatctattg gacaatagta
+     1501 aaaccgggag acatactttt gattaacagc acagggaatc taattgctcc taggggttac
+     1561 ttcaaaatac gaagtgggaa aagctcaata atgagatcag acgcacccat tggcaaatgt
+     1621 aagtctgaat gcatcactcc aaatggaagc attcccaatg acaaaccgtt ccaaaatgta
+     1681 aacaggatca catacggggc ctgtcccaga tacgttaagc aaagcaccct gaaattggca
+     1741 acaggaatgc gaaatgtacc tgagaaacaa accagaggca tatttggtgc aatagcgggt
+     1801 ttcatagaaa atggatggga gggaatggtg gatggttggt acggtttcag gcatcaaaat
+     1861 tctgagggaa gaggacaagc agcagatctc aaaagcactc aagcagcaat cgatcaaatc
+     1921 agtgggaagc tgaatcgatt gatcggaaaa accaacgaga aattccatca gattgaaaaa
+     1981 gaattctcag aagtagaagg aagagttcaa gacctcgaga aatatgttga ggacactaaa
+     2041 atagatctct ggtcatacaa cgcggagctt cttgttgccc tggagaacca acatacgatt
+     2101 gacctaactg actcagaaat gaacaagctg tttgaaaaaa caaagaagca actgagggaa
+     2161 aatgctgagg atatgggaaa tggttgtttc aaaatatacc acaaatgtga caatgcctgc
+     2221 ataggatcaa taagaaatga aacttatgac cacaatgtgt acagggatga agcattaaac
+     2281 aaccggttcc agatcaaggg agttgagctg aagtcaggat acaaagattg gatcctatgg
+     2341 atttcctttg ccATGtcTtg CttCCtActG tgCgtAgcAC tACtAggCtt TatTatgtgg
+     2401 gcGtgTcaGa aAggCtcCCt AcaAtgTCgG atTtgTatTT AATAGNNNNN NNNNNNNNNN
+     2461 Nagatcggaa gagcgtcgtg tagggaaaga gtgtgcggcc gctatctact caactgtcgc
+     2521 cagttcactg gtgctttagg tctccctggg ggcaatcagt ttctggatgt gttctaatgg
+     2581 gtctttgcag tgcagaatat gcatctgaga ttaggatttc agaaatataa ggaaaaacac
+     2641 ccttgtttct actaataacc cggcggccca aaatgccgac tcggagcgaa agatatacct
+     2701 cccccggggc cgggaggtcg cgtcaccgac cacgccgccg gcccaggcga cgcgcgacac
+     2761 ggacacctgt ccccaaaaac gccaccatcg cagccacaca cggagcgccc ggggccctct
+     2821 ggtcaacccc aggacacacg cgggagcagc gccgggccgg ggacgccctc ccggccgccc
+     2881 gtgccacacg cagggggccg gcccgtgtct ccagagcggg agccggaagc attttcggcc
+     2941 ggcccctcct acgaccggga cacacgaggg accgaaggcc ggccaggcgc gacctctcgg
+     3001 gccgcacgcg cgctcaggga gcgctctccg actccgcacg gggactcgcc agaaaggatc
+     3061 gtgatctgca ttaatgaatc aggggataac gcaggaaaga acatgtgagc aaaaggccag
+     3121 caaaaggcca ggaaccgtaa aaaggccgcg ttgctggcgt ttttccatag gctccgcccc
+     3181 cctgacgagc atcacaaaaa tcgacgctca agtcagaggt ggcgaaaccc gacaggacta
+     3241 taaagatacc aggcgtttcc ccctggaagc tccctcgtgc gctctcctgt tccgaccctg
+     3301 ccgcttaccg gatacctgtc cgcctttctc ccttcgggaa gcgtggcgct ttctcatagc
+     3361 tcacgctgta ggtatctcag ttcggtgtag gtcgttcgct ccaagctggg ctgtgtgcac
+     3421 gaaccccccg ttcagcccga ccgctgcgcc ttatccggta actatcgtct tgagtccaac
+     3481 ccggtaagac acgacttatc gccactggca gcagccactg gtaacaggat tagcagagcg
+     3541 aggtatgtag gcggtgctac agagttcttg aagtggtggc ctaactacgg ctacactaga
+     3601 agaacagtat ttggtatctg cgctctgctg aagccagtta ccttcggaaa aagagttggt
+     3661 agctcttgat ccggcaaaca aaccaccgct ggtagcggtg gtttttttgt ttgcaagcag
+     3721 cagattacgc gcagaaaaaa aggatctcaa gaagatcctt tgatcttttc tacggggtct
+     3781 gacgctcagt ggaacgaaaa ctcacgttaa gggattttgg tcatgagatt atcaaaaagg
+     3841 atcttcacct agatcctttt aaattaaaaa tgaagtttta aatcaatcta aagtatatat
+     3901 gagtaaactt ggtctgacag ttaccaatgc ttaatcagtg aggcacctat ctcagcgatc
+     3961 tgtctatttc gttcatccat agttgcctga ctccccgtcg tgtagataac tacgatacgg
+     4021 gagggcttac catctggccc cagtgctgca atgataccgc gagacccacg ctcaccggct
+     4081 ccagatttat cagcaataaa ccagccagcc ggaagggccg agcgcagaag tggtcctgca
+     4141 actttatccg cctccatcca gtctattaat tgttgccggg aagctagagt aagtagttcg
+     4201 ccagttaata gtttgcgcaa cgttgttgcc attgctacag gcatcgtggt gtcacgctcg
+     4261 tcgtttggta tggcttcatt cagctccggt tcccaacgat caaggcgagt tacatgatcc
+     4321 cccatgttgt gcaaaaaagc ggttagctcc ttcggtcctc cgatcgttgt cagaagtaag
+     4381 ttggccgcag tgttatcact catggttatg gcagcactgc ataattctct tactgtcatg
+     4441 ccatccgtaa gatgcttttc tgtgactggt gagtactcaa ccaagtcatt ctgagaatag
+     4501 tgtatgcggc gaccgagttg ctcttgcccg gcgtcaacac gggataatac cgcgccacat
+     4561 agcagaactt taaaagtgct catcattgga aaacgttctt cggggcgaaa actctcaagg
+     4621 atcttaccgc tgttgagatc cagttcgatg taacccactc gtgcacccaa ctgatcttca
+     4681 gcatctttta ctttcaccag cgtttctggg tgagcaaaaa caggaaggca aaatgccgca
+     4741 aaaaagggaa taagggcgac acggaaatgt tgaatactca t
+//


### PR DESCRIPTION
These are example H1 and H3 plasmid maps. I added a lot of (hopefully helpful) annotations, highlights include:
* regions w WSN sequence (the upstream and downstream regions differ between H1 and H3)
* recoded downstream endodomain and CT sequence regions (to avoid homology with duplicated package sequence)
* regions actually ordered from Twist for the `flu-seqneut-2025` library